### PR TITLE
Adding inline options

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -320,8 +320,8 @@ function ensureTwitterAppTab(window) {
     return tab.pinned && URI.host == "twitter.com";
   });
 
-  // No need to add!
-  if (!justInstalled && !twitterTab) {
+  // Only add the app tab if one DNE already and the ext was just insatlled
+  if (justInstalled && !twitterTab) {
     // Add the tab and pin it as the last app tab
     twitterTab = gBrowser.addTab(getTwitterBase("", "apptab"));
     gBrowser.pinTab(twitterTab);

--- a/bootstrap.js
+++ b/bootstrap.js
@@ -286,7 +286,7 @@ function ensureTwitterAppTab(window) {
         command.getAttribute("oncommand").replace(/TwitterAddressBarSearch.openLocation\(\);/, ""));
 
     delete window["TwitterAddressBarSearch"];
-  });
+  }, window);
 
 
   // Figure out if we already have a pinned twitter

--- a/bootstrap.js
+++ b/bootstrap.js
@@ -306,6 +306,11 @@ function ensureTwitterAppTab(window) {
     // Add attribute that'll flag this tab as the one we care about
     twitterTab.setAttribute(TAB_ATTR_NAME, "true");
 
+    // disable chrome now if the current tab is the twitter app tab
+    if (gBrowser.selectedTab.hasAttribute(TAB_ATTR_NAME)) {
+      document.documentElement.setAttribute("disablechrome", "true");
+    }
+
     // Removes the twitter tab when uninstalling
     unload(function() gBrowser.removeTab(twitterTab));
   }

--- a/bootstrap.js
+++ b/bootstrap.js
@@ -19,6 +19,7 @@
  *
  * Contributor(s):
  *   Edward Lee <edilee@mozilla.com>
+ *   Erik Vold <erikvvold@gmail.com>
  *
  * Alternatively, the contents of this file may be used under the terms of
  * either the GNU General Public License Version 2 or later (the "GPL"), or

--- a/bootstrap.js
+++ b/bootstrap.js
@@ -259,9 +259,9 @@ function ensureTwitterAppTab(window) {
     return;
   }
 
-  // TODO: need user pref to control this..
-  // Listens to tab selection events
-  function switchChrome(aDisable, aHasAttr) {Services.console.logStringMessage("switchChrome");
+  function switchChrome(aDisable, aHasAttr) {
+    if (!getPref("hideChromeForAppTab")) return;
+
     aHasAttr = aHasAttr || gBrowser.selectedTab.hasAttribute(TAB_ATTR_NAME);
     if (!aHasAttr || aDisable)
       document.documentElement.removeAttribute("disablechrome");
@@ -273,6 +273,7 @@ function ensureTwitterAppTab(window) {
       __SCRIPT_URI_SPEC__ + "/../scripts/browser.js", window);
   window.TwitterAddressBarSearch.openLocation = switchChrome.bind(null, true);
   window.TwitterAddressBarSearch.TAB_ATTR_NAME = TAB_ATTR_NAME;
+  window.TwitterAddressBarSearch.getPref = getPref;
 
   var command = document.getElementById("Browser:OpenLocation");
   command.setAttribute("oncommand",
@@ -358,10 +359,13 @@ function showLandingPage(window) {
  */
 function startup({id}, reason) AddonManager.getAddonByID(id, function(addon) {
   // Load various javascript includes for helper functions
-  ["helper", "utils"].forEach(function(fileName) {
+  ["prefs", "helper", "utils"].forEach(function(fileName) {
     let fileURI = addon.getResourceURI("scripts/" + fileName + ".js");
     Services.scriptloader.loadSubScript(fileURI.spec, global);
   });
+
+  // Always set the default prefs as they disappear on restart
+  setDefaultPrefs();
 
   // Add twitter support to the browser
   watchWindows(addTwitterAddressBarSearch);

--- a/install.rdf
+++ b/install.rdf
@@ -11,6 +11,7 @@
 
     <bootstrap>true</bootstrap>
     <type>2</type>
+    <optionsType>2</optionsType>
 
     <contributor>Erik Vold</contributor>
 

--- a/install.rdf
+++ b/install.rdf
@@ -12,6 +12,8 @@
     <bootstrap>true</bootstrap>
     <type>2</type>
 
+    <contributor>Erik Vold</contributor>
+
     <targetApplication>
       <r:Description>
         <id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</id>

--- a/options.xul
+++ b/options.xul
@@ -1,0 +1,6 @@
+<?xml version="1.0"?> 
+<vbox xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul">
+  <setting pref="extensions.twitter-address-bar-search.hideChromeForAppTab"
+      type="bool"
+      title="Hide chrome in app tab"/>
+</vbox>

--- a/scripts/browser.js
+++ b/scripts/browser.js
@@ -1,0 +1,56 @@
+/* ***** BEGIN LICENSE BLOCK *****
+ * Version: MPL 1.1/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Mozilla Public License Version
+ * 1.1 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * http://www.mozilla.org/MPL/
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+ * for the specific language governing rights and limitations under the
+ * License.
+ *
+ * The Original Code is Twitter Address Bar Search.
+ *
+ * The Initial Developer of the Original Code is The Mozilla Foundation.
+ * Portions created by the Initial Developer are Copyright (C) 2011
+ * the Initial Developer. All Rights Reserved.
+ *
+ * Contributor(s):
+ *   Erik Vold <erikvvold@gmail.com>
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either the GNU General Public License Version 2 or later (the "GPL"), or
+ * the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the MPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the MPL, the GPL or the LGPL.
+ *
+ * ***** END LICENSE BLOCK ***** */
+
+// Create window.TwitterAddressBarSearch
+(function(window) {
+  var self = window.TwitterAddressBarSearch = {
+    _testFunc: function(aURL) {
+      return /^https?:\/\/(?:\w+\.)?twitter.com/i.test(aURL)
+          && window.gBrowser.selectedTab.hasAttribute(self.TAB_ATTR_NAME);
+    }
+  };
+})(this);
+
+// Overwrite XULBrowserWindow.hideChromeForLocation
+(function(window) {
+  var XULBrowserWindow = window.XULBrowserWindow;
+  var oldFunc = XULBrowserWindow.hideChromeForLocation;
+  XULBrowserWindow.hideChromeForLocation = function(aURL) {
+    var testFunc = window.TwitterAddressBarSearch;
+    if (testFunc) testFunc = testFunc._testFunc;
+    return (testFunc && testFunc(aURL)) || oldFunc.call(XULBrowserWindow, aURL);
+  };
+})(this);


### PR DESCRIPTION
A follow up to #1, displaying the `extensions.twitter-address-bar-search.hideChromeForAppTab` in the EM for FF7+ users
